### PR TITLE
weechat-sasl-simply: fix links

### DIFF
--- a/_posts/2015-03-26-weechat-sasl-simply.md
+++ b/_posts/2015-03-26-weechat-sasl-simply.md
@@ -19,8 +19,8 @@ First set mechanism as plain if you have it as anything else. Many people
 have it as DH- something which are insecure and is removed from more modern
 services packages. More about that:
 
-* https://nullroute.eu.org/~grawity/irc-sasl-dh.html
-* http://kaniini.dereferenced.org/2014/12/26/do-not-use-DH-AES-or-DH-BLOWFISH.html
+* [On the security of SASL DH-BLOWFISH (at nullroute.eu.org)](https://nullroute.eu.org/~grawity/irc-sasl-dh.html)
+* [Do not use or provide DH-AES or DH-BLOWFISH for SASL/IAL authentication (at kaniini.dereferenced.org)](http://kaniini.dereferenced.org/2014/12/26/do-not-use-DH-AES-or-DH-BLOWFISH.html)
 
 ```
 /set irc.server_default.sasl_mechanism PLAIN


### PR DESCRIPTION
I say "(at domain.tld)" to make sure people understand without clicking that those are not my articles.